### PR TITLE
wordfence-cli: init at 5.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1338,6 +1338,11 @@
     name = "alyaeanyx";
     keys = [ { fingerprint = "1F73 8879 5E5A 3DFC E2B3 FA32 87D1 AADC D25B 8DEE"; } ];
   };
+  am-on = {
+    name = "Amon Stopinšek";
+    github = "am-on";
+    githubId = 8530224;
+  };
   amadaluzia = {
     email = "amad@atl.tools";
     github = "amadaluzia";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1466,6 +1466,7 @@ in
   wmderland = handleTest ./wmderland.nix { };
   workout-tracker = handleTest ./workout-tracker.nix { };
   wpa_supplicant = import ./wpa_supplicant.nix { inherit pkgs runTest; };
+  wordfence-cli = handleTest ./wordfence-cli.nix { };
   wordpress = runTest ./wordpress.nix;
   wrappers = handleTest ./wrappers.nix { };
   writefreely = import ./web-apps/writefreely.nix { inherit pkgs runTest; };

--- a/nixos/tests/wordfence-cli.nix
+++ b/nixos/tests/wordfence-cli.nix
@@ -1,0 +1,25 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "wordfence-cli";
+    meta.maintainers = with lib.maintainers; [ am-on ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = with pkgs; [
+          wordfence-cli
+        ];
+
+      };
+
+    testScript = ''
+      start_all()
+
+      output = machine.succeed("wordfence --version")
+      assert "PCRE Supported: Yes" in output
+      assert "Vectorscan Supported: Yes" in output
+    '';
+  }
+)

--- a/pkgs/tools/security/wordfence-cli/default.nix
+++ b/pkgs/tools/security/wordfence-cli/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  pkg-config,
+  pcre,
+  hyperscan,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "wordfence-cli";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "wordfence";
+    repo = "wordfence-cli";
+    rev = "v${version}";
+    sha256 = "13hb1xikm8824hhfmv9ggmmkp637yfkf7z58338p66z9l7hsjq1i";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    pkg-config
+    setuptools
+    pip
+    pcre
+    hyperscan
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    packaging
+    requests
+    pymysql
+  ];
+
+  patches = [
+    ./library.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace wordfence/util/library.py \
+      --replace '@PCRE_OUT@' "${pcre.out}" \
+      --replace '@HS_OUT@'  "${hyperscan.out}"
+  '';
+
+  format = "pyproject";
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Wordfence malware and vulnerability scanner command line utility";
+    homepage = "https://github.com/wordfence/wordfence-cli";
+    changelog = "https://github.com/wordfence/wordfence-cli/releases";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [
+      am-on
+    ];
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
+}

--- a/pkgs/tools/security/wordfence-cli/library.patch
+++ b/pkgs/tools/security/wordfence-cli/library.patch
@@ -1,0 +1,17 @@
+--- a/wordfence/util/library.py	2022-01-01 00:00:00.000000000 +0000
++++ b/wordfence/util/library.py	2022-01-01 00:00:00.000000000 +0000
+@@ -8,7 +8,12 @@
+
+
+ def load_library(name: str) -> CDLL:
+-    pathname = find_library(name)
++    if name == "pcre":
++        pathname = "@PCRE_OUT@/lib/libpcre.so"
++    elif name == "hs":
++        pathname = "@HS_OUT@/lib/libhs.so"
++    else:
++        pathname = find_library(name)
+     if pathname is None:
+         raise LibraryNotAvailableException()
+     try:
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4708,6 +4708,8 @@ with pkgs;
     callPackage ../development/tools/continuous-integration/woodpecker/server.nix
       { };
 
+  wordfence-cli = callPackage ../tools/security/wordfence-cli { };
+
   wpscan = callPackage ../tools/security/wpscan { };
 
   testdisk = libsForQt5.callPackage ../tools/system/testdisk { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
